### PR TITLE
Hint about CaseClass1Rep implicits generated for `@tagged` types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributor Guidelines
+
+Thank you for your interest in contributing. To begin, please follow the steps below.
+
+## Find an Issue
+
+Please [open an issue](https://github.com/theiterators/kebs-intellij/issues/new) if you have found a bug, or you have any idea how to improve experience with [kebs](https://github.com/theiterators/kebs) in IntelliJ IDEA.
+
+if you have no ideas about what to contribute, you can check project's [issue tracker](https://github.com/theiterators/kebs-intellij/issues).
+
+## Build and run the project
+
+Clone project using git. Once cloned, open it in IntelliJ and import as sbt project.
+
+Project uses [sbt-idea-plugin](https://github.com/JetBrains/sbt-idea-plugin) to define runtime configuration "kebs-intellij".
+Using it you can run a new instance of IntelliJ with actual plugin code.
+
+All features of the plugin are tested with unit tests. Please remember to write tests to the code you want to contribute.
+
+## Code formatting
+
+You can use sbt command to format the code:
+```
+sbt fmt
+```
+
+## Merge request
+
+Once you have a code that closes an issue (does not matter if opened by you or someone else) you can
+[create a merge request](https://github.com/theiterators/kebs-intellij/compare) and wait for a review and merge
+into the main branch (before that you might be requested for changes that improve your contribution and make it follow
+existing conventions in the code base).
+
+If you get stuck, please consider opening a pull request for your incomplete work, and asking for help (just prefix
+the pull request by *WIP*). In addition, you can comment on the original issue, pointing people to your own fork.

--- a/README.md
+++ b/README.md
@@ -33,14 +33,6 @@ See https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_fro
 
 * Tagged types without a qualified name (e.g. local classes) are not supported by the plugin (although they are supported by kebs-tagged-meta).
 
-## Development
-
-Open plugin project in IntelliJ as usual. Sbt defines runtime configuration "kebs-intellij" which runs a new instance of IntelliJ with actual plugin code.
-
-## Contributing
-
-Like what you see? Help improve this plugin by submitting issues and ideas!
-
 ## Acknowledgments
 
 Plugin code was influenced by [zio-intellij](https://github.com/zio/zio-intellij) project.

--- a/README.md
+++ b/README.md
@@ -29,15 +29,19 @@ Plugin jar is located in `target/plugin/kebs-intellij/lib/` directory of the pro
 
 See https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk for instructions how to install the plugin from disk.
 
+## Known limitations
+
+* Tagged types without a qualified name (e.g. local classes) are not supported by the plugin (although they are supported by kebs-tagged-meta).
+
 ## Development
 
 Open plugin project in IntelliJ as usual. Sbt defines runtime configuration "kebs-intellij" which runs a new instance of IntelliJ with actual plugin code.
 
-## Known limitations
+## Contributing
 
- * Tagged types without a qualified name (e.g. local classes) are not supported by the plugin (although they are supported by kebs-tagged-meta).
+Like what you see? Help improve this plugin by submitting issues and ideas!
 
-## Credits
+## Acknowledgments
 
 Plugin code was influenced by [zio-intellij](https://github.com/zio/zio-intellij) project.
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,13 +18,19 @@ lazy val `kebs-intellij` = project
     ),
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
     patchPluginXml := pluginXmlOptions { xml =>
-      xml.version     = version.value
-      xml.changeNotes = """<![CDATA[
-        TBD
-        <ul>
-          <li>TBD</li>
-        </ul>
-      ]]>"""
+      xml.version = version.value
+      xml.changeNotes =
+        """<![CDATA[
+          Support for upcoming versions of IntelliJ and bugfixes.
+          <ul>
+            <li>support for IntelliJ IDEA 2021.*</li>
+            <li>
+              support for <code>CaseClass1Rep</code> implicits - add hints in IntelliJ IDEA for the implicits generated
+              by kebs-tagged-meta for tags in objects and traits tagged with
+              <a href="https://github.com/theiterators/kebs#tagged-types"><code>@tagged</code></a> annotation (#1)
+            </li>
+          </ul>
+        ]]>"""
     }
   )
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,7 +15,7 @@
 
     <change-notes>replaced-by-build</change-notes>
 
-    <idea-version since-build="203" until-build="203.*"/>
+    <idea-version since-build="203" until-build="211.*"/>
 
     <depends>org.intellij.scala</depends>
     <depends>com.intellij.java</depends>

--- a/src/main/scala/pl/iterators/kebs/intellij/TypeUtils.scala
+++ b/src/main/scala/pl/iterators/kebs/intellij/TypeUtils.scala
@@ -1,0 +1,42 @@
+package pl.iterators.kebs.intellij
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScTypeAlias, ScTypeAliasDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScTemplateDefinition, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.types.{ScParameterizedType, ScType}
+
+object TypeUtils {
+
+  def getTypeDefinition(templateDefinition: ScTemplateDefinition): Option[ScTypeDefinition] =
+    for {
+      typeName       <- getTypeName(templateDefinition)
+      typeDefinition <- getTypeDefinition(templateDefinition.getProject, typeName)
+    } yield typeDefinition
+
+  def getTypeDefinition(project: Project, qualifiedName: String): Option[ScTypeDefinition] =
+    JavaPsiFacade.getInstance(project).findClass(qualifiedName, GlobalSearchScope.projectScope(project)) match {
+      case typeDef: ScTypeDefinition => Some(typeDef)
+      case _                         => None
+    }
+
+  def getTypeName(templateDefinition: ScTemplateDefinition): Option[String] =
+    for {
+      objectClassType <- templateDefinition.`type`().toOption
+      objectClass     <- objectClassType.extractClass
+      className       <- Option(objectClass.getQualifiedName)
+    } yield className
+
+  def getTypeAliasDefinition(typeAlias: ScTypeAlias): Option[ScTypeAliasDefinition] =
+    typeAlias match {
+      case definition: ScTypeAliasDefinition => Some(definition)
+      case _                                 => None
+    }
+
+  def getParameterizedType(scType: ScType): Option[ScParameterizedType] =
+    scType match {
+      case parameterizedType: ScParameterizedType => Some(parameterizedType)
+      case _                                      => None
+    }
+}

--- a/src/main/scala/pl/iterators/kebs/intellij/package.scala
+++ b/src/main/scala/pl/iterators/kebs/intellij/package.scala
@@ -1,0 +1,5 @@
+package pl.iterators.kebs
+
+package object intellij {
+  val kebsPackage = "pl.iterators.kebs"
+}

--- a/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjector.scala
+++ b/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjector.scala
@@ -2,6 +2,7 @@ package pl.iterators.kebs.intellij.synthetic.macros
 
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTemplateDefinition, ScTypeDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
+import pl.iterators.kebs.intellij.kebsPackage
 
 class TaggedInjector extends SyntheticMembersInjector {
 
@@ -11,28 +12,39 @@ class TaggedInjector extends SyntheticMembersInjector {
   // type alias with tag (also check if there is validate method, because it changes signature of `from` function (to inject))
   override def injectFunctions(source: ScTypeDefinition): Seq[String] =
     source match {
-      case scObject: ScObject if isTagged(scObject.containingClass) =>
-        (for {
-          typeWithTag <- TypeWithTag.fromTypeObject(scObject)
-          functions = typeWithTag.makeFunctionsForTypeObject(scObject)
-        } yield functions).toSeq.flatten
-      case _ => Nil
+      case TaggedTypeObject(scObject, typeWithTag) => typeWithTag.makeFunctionsForTypeObject(scObject)
+      case _                                       => Nil
     }
 
   // inject object with `apply` and `from` functions for each type with tag in tagged object or trait
   override def injectInners(source: ScTypeDefinition): Seq[String] =
     source match {
-      case templateDefinition: ScTemplateDefinition if isTagged(templateDefinition) =>
-        for {
-          typeWithTag <- TypeWithTag.fromTypeWithNoTypeObject(templateDefinition)
-          typeObject = typeWithTag.makeTypeObject
-        } yield typeObject
-      case _ => Nil
+      case TaggedContainer(typesWithTags) => typesWithTags.map(_.makeTypeObject)
+      case _                              => Nil
     }
 }
 
 object TaggedInjector {
-  private val taggedAnnotation = "pl.iterators.kebs.tag.meta.tagged"
+
+  private val taggedAnnotation = s"$kebsPackage.tag.meta.tagged"
+
+  private object TaggedTypeObject {
+    def unapply(source: ScTypeDefinition): Option[(ScObject, TypeWithTag)] =
+      source match {
+        case scObject: ScObject if isTagged(scObject.containingClass) =>
+          TypeWithTag.fromTypeObject(scObject).map(typeWithTag => (scObject, typeWithTag))
+        case _ => None
+      }
+  }
+
+  private object TaggedContainer {
+    def unapply(source: ScTypeDefinition): Option[Seq[TypeWithTag]] =
+      source match {
+        case templateDefinition: ScTemplateDefinition if isTagged(templateDefinition) =>
+          Some(TypeWithTag.fromTypeWithNoTypeObject(templateDefinition))
+        case _ => None
+      }
+  }
 
   private def isTagged(templateDefinition: ScTemplateDefinition): Boolean =
     templateDefinition match {

--- a/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjector.scala
+++ b/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjector.scala
@@ -1,12 +1,37 @@
 package pl.iterators.kebs.intellij.synthetic.macros
 
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTemplateDefinition, ScTypeDefinition}
+import com.intellij.psi.PsiClass
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{
+  ScObject,
+  ScTemplateDefinition,
+  ScTrait,
+  ScTypeDefinition
+}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
+import pl.iterators.kebs.intellij.TypeUtils.getTypeDefinition
 import pl.iterators.kebs.intellij.kebsPackage
 
 class TaggedInjector extends SyntheticMembersInjector {
 
   import TaggedInjector._
+
+  // we need companion object for every tag, since macro generates implicit CaseClass1Rep there
+  // we cannot inject whole object in injectInners since:
+  // * it can be already defined by the user
+  // * https://youtrack.jetbrains.com/issue/SCL-18708
+  override def needsCompanionObject(source: ScTypeDefinition): Boolean =
+    source match {
+      case scTrait: ScTrait if hasTaggedAnnotation(scTrait.containingClass) && scTrait.members.isEmpty =>
+        true
+      case _ => false
+    }
+
+  // inject implicit CaseClass1Rep into tags companion objects
+  override def injectMembers(source: ScTypeDefinition): Seq[String] =
+    source match {
+      case TagObject(typesWithTags) => typesWithTags.map(_.makeCaseClass1RepTagImplicit)
+      case _                        => Nil
+    }
 
   // inject `apply` and `from` functions to object if it is in tagged object/trait and in the containing type there is
   // type alias with tag (also check if there is validate method, because it changes signature of `from` function (to inject))
@@ -28,10 +53,33 @@ object TaggedInjector {
 
   private val taggedAnnotation = s"$kebsPackage.tag.meta.tagged"
 
+  private object TagObject {
+    def unapply(source: ScTypeDefinition): Option[Seq[TypeWithTag]] =
+      source match {
+        case tagCompanionObject: ScObject if hasTaggedAnnotation(tagCompanionObject.containingClass) =>
+          val tagClass             = tagCompanionObject.fakeCompanionClassOrCompanionClass
+          val taggedContainerClass = tagCompanionObject.containingClass
+          for {
+            taggedContainer <- getTypeDefinition(taggedContainerClass)
+            if isTagAnEmptyTrait(taggedContainer, tagClass)
+          } yield makeTypesWithTagSeq(taggedContainer, tagClass)
+        case _ => None
+      }
+    private def isTagAnEmptyTrait(taggedContainer: ScTypeDefinition, tagClass: PsiClass) =
+      taggedContainer.typeDefinitions
+        .filter(t => t.isInstanceOf[ScTrait] && t.getSourceMirrorClass == tagClass)
+        .map(_.asInstanceOf[ScTrait])
+        .exists(_.members.isEmpty)
+    private def makeTypesWithTagSeq(taggedContainer: ScTypeDefinition, tagClass: PsiClass) =
+      taggedContainer.aliases
+        .flatMap(alias => TypeWithTag.fromTypeAlias(alias).toList)
+        .filter(typeWithTag => typeWithTag.tagType.extractClass.contains(tagClass))
+  }
+
   private object TaggedTypeObject {
     def unapply(source: ScTypeDefinition): Option[(ScObject, TypeWithTag)] =
       source match {
-        case scObject: ScObject if isTagged(scObject.containingClass) =>
+        case scObject: ScObject if hasTaggedAnnotation(scObject.containingClass) =>
           TypeWithTag.fromTypeObject(scObject).map(typeWithTag => (scObject, typeWithTag))
         case _ => None
       }
@@ -40,19 +88,19 @@ object TaggedInjector {
   private object TaggedContainer {
     def unapply(source: ScTypeDefinition): Option[Seq[TypeWithTag]] =
       source match {
-        case templateDefinition: ScTemplateDefinition if isTagged(templateDefinition) =>
-          Some(TypeWithTag.fromTypeWithNoTypeObject(templateDefinition))
+        case templateDefinition: ScTemplateDefinition if hasTaggedAnnotation(templateDefinition) =>
+          Some(TypeWithTag.collectAllWithNoTypeObject(templateDefinition))
         case _ => None
       }
   }
 
-  private def isTagged(templateDefinition: ScTemplateDefinition): Boolean =
+  private def hasTaggedAnnotation(templateDefinition: ScTemplateDefinition): Boolean =
     templateDefinition match {
-      case typeDefinition: ScTypeDefinition => isTagged(typeDefinition)
+      case typeDefinition: ScTypeDefinition => hasTaggedAnnotation(typeDefinition)
       case _                                => false
     }
 
-  private def isTagged(typeDefinition: ScTypeDefinition): Boolean =
+  private def hasTaggedAnnotation(typeDefinition: ScTypeDefinition): Boolean =
     typeDefinition.hasAnnotation(taggedAnnotation) && (typeDefinition.isObject || typeDefinition.isInterface)
 
 }

--- a/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/ValidateFunction.scala
+++ b/src/main/scala/pl/iterators/kebs/intellij/synthetic/macros/ValidateFunction.scala
@@ -8,20 +8,17 @@ case class ValidateFunction(errorType: ScType)
 object ValidateFunction {
 
   def find(scObject: ScObject): Option[ValidateFunction] =
-    scObject.functions.find(_.name == "validate") match {
-      case Some(validateFunction) =>
-        for {
-          scType    <- validateFunction.returnType.toOption
-          errorType <- leftFromEither(scType)
-        } yield ValidateFunction(errorType)
-      case None => None
+    scObject.functions.find(_.name == "validate").flatMap { validateFunction =>
+      for {
+        scType    <- validateFunction.returnType.toOption
+        errorType <- leftFromEither(scType)
+      } yield ValidateFunction(errorType)
     }
 
-  private def leftFromEither(scType: ScType) = scType match {
+  private def leftFromEither(scType: ScType): Option[ScType] = scType match {
     case parameterizedType: ScParameterizedType
         if parameterizedType.designator.toString == "Either" && parameterizedType.typeArguments.size == 2 =>
       Some(parameterizedType.typeArguments.head)
     case _ => None
   }
-
 }

--- a/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTagObjectTest.scala
+++ b/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTagObjectTest.scala
@@ -1,0 +1,70 @@
+package pl.iterators.kebs.intellij.synthetic.macros
+
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.testFramework.LightPlatformTestCase
+import org.jetbrains.plugins.scala.ScalaLightCodeInsightFixtureTestAdapter.normalize
+import org.jetbrains.plugins.scala.inWriteAction
+
+class TaggedInjectorInjectTagObjectTest extends MacrosTest {
+
+  private val taggedExampleCode =
+    s"""
+       |import pl.iterators.kebs.tagged._
+       |import pl.iterators.kebs.tag.meta.tagged
+       |
+       |@tagged object TaggedExample {
+       |  trait CompanyTag
+       |  trait DepartmentTag
+       |  trait PositionTag
+       |  trait NameTag
+       |  trait IdTag[+A]
+       |
+       |  type Company    = String @@ CompanyTag
+       |  type Department = String @@ DepartmentTag
+       |  type Position   = String @@ PositionTag
+       |  type Name       = String @@ NameTag
+       |  type Id[A]      = Int @@ IdTag[A]
+       |
+       |  object Name {
+       |    val empty = "".asInstanceOf[Name]
+       |  }
+       |  object DepartmentTag {}
+       |  object PositionTag {}
+       |}
+       |""".stripMargin
+
+  override protected val code = ""
+
+  override def setUp(): Unit = {
+    super.setUp()
+    inWriteAction {
+      val sourceRoot = LightPlatformTestCase.getSourceRoot
+      VfsUtil.saveText(sourceRoot.createChildData(null, "TaggedExample.scala"), normalize(taggedExampleCode))
+    }
+  }
+
+  private def testCode(testName: String, implicitText: String): String =
+    s"""
+      |import pl.iterators.kebs.macros.CaseClass1Rep
+      |import TaggedExample._
+      |
+      |object $testName {
+      |  $implicitText
+      |}
+      |""".stripMargin
+
+  def testImplicitWhenNoTagObjectAndNoTaggedTypeObject(): Unit =
+    checkTextHasNoErrors(testCode("NoTagObjectAndNoTaggedTypeObject", "implicitly[CaseClass1Rep[Company, String]]"))
+
+  def testImplicitWhenTagObjectAndNoTaggedTypeObject(): Unit =
+    checkTextHasNoErrors(testCode("TagObjectAndNoTaggedTypeObject", "implicitly[CaseClass1Rep[Department, String]]"))
+
+  def testImplicitWhenNoTagObjectAndTaggedTypeObject(): Unit =
+    checkTextHasNoErrors(testCode("NoTagObjectAndTaggedTypeObject", "implicitly[CaseClass1Rep[Name, String]]"))
+
+  def testImplicitWhenTagObjectAndTaggedTypeObject(): Unit =
+    checkTextHasNoErrors(testCode("TagObjectAndTaggedTypeObject", "implicitly[CaseClass1Rep[Position, String]]"))
+
+  def testImplicitForGenericTag(): Unit =
+    checkTextHasNoErrors(testCode("GenericTag", "implicitly[CaseClass1Rep[Id[String], Int]]"))
+}

--- a/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectTest.scala
+++ b/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectTest.scala
@@ -2,7 +2,7 @@ package pl.iterators.kebs.intellij.synthetic.macros
 
 import org.junit.Assert.assertEquals
 
-class TaggedInjectorInjectObjectTest extends MacrosTest {
+class TaggedInjectorInjectTaggedTypeObjectTest extends MacrosTest {
 
   override protected val code =
     s"""package test.unit

--- a/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectWithTypeFromPackageObjectTest.scala
+++ b/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectWithTypeFromPackageObjectTest.scala
@@ -5,7 +5,7 @@ import com.intellij.testFramework.LightPlatformTestCase
 import org.jetbrains.plugins.scala.ScalaLightCodeInsightFixtureTestAdapter.normalize
 import org.jetbrains.plugins.scala.inWriteAction
 
-class TaggedInjectorInjectObjectWithTypeFromPackageObjectTest extends MacrosTest {
+class TaggedInjectorInjectTaggedTypeObjectWithTypeFromPackageObjectTest extends MacrosTest {
 
   private val packageObject =
     s"""package test


### PR DESCRIPTION
Add hints for the `CaseClass1Rep` implicits generated for tags in objects and traits tagged with `@tagged` annotation.

Extend supported IDEA versions to 2021.*

Add Contributor Guidelines,

Closes #1