### PR TITLE
Support for IntelliJ 2025.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,25 +16,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: "openjdk@1.17.0"
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-            ~/.kebs-intellijPluginIC/
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}-${{ hashFiles('project/plugins.sbt') }}
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
+
+      - name: Retry setup-sbt once (macOS)
+        if: runner.os == 'macOS' && steps.setup_sbt.outcome == 'failure'
+        uses: sbt/setup-sbt@v1
+        continue-on-error: true
+
+      - name: Fallback install sbt (macOS)
+        if: runner.os == 'macOS' && failure()
+        run: brew install sbt
 
       - name: Run tests
         run: sbt test
@@ -45,25 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: "openjdk@1.17.0"
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
 
-      - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-            ~/.kebs-intellijPluginIC/
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}-${{ hashFiles('project/plugins.sbt') }}
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
 
       - name: Build the plugin
         run: sbt test packageArtifact
@@ -77,6 +70,7 @@ jobs:
           verifier-version: '1.384'
           ide-versions: |
             ideaIC:2025.2
+            ideaIC:2025.3
           failure-levels: |
             COMPATIBILITY_PROBLEMS
             INVALID_PLUGIN

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,17 @@ jobs:
       IJ_PLUGIN_REPO_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Scala
-        uses: olafurpg/setup-scala@v14
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: "openjdk@1.17.0"
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
+
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
 
       - name: Package plugin
         # For some reason packageArtifact needs to be invoked second time

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.2-open
+java=21.0.9-jbr

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organizationHomepage := Some(url("https://iteratorshq.com/"))
 ThisBuild / intellijPluginName := "kebs-intellij"
 // List of release versions: https://www.jetbrains.com/intellij-repository/releases
 // List of snapshot versions: https://www.jetbrains.com/intellij-repository/snapshots
-ThisBuild / intellijBuild := "252.23892.409"
+ThisBuild / intellijBuild := "253.28294.334"
 
 ThisBuild / scalacOptions ++= Seq(
   "-explaintypes",
@@ -30,8 +30,7 @@ lazy val `kebs-intellij` = project
   .settings(
     intellijPlugins := Seq(
       "com.intellij.java".toPlugin, // this is not required in the runtime, although it is required by JetBrains, see https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
-      "org.intellij.scala".toPlugin,
-      "org.intellij.intelliLang".toPlugin
+      "org.intellij.scala".toPlugin
     ),
     libraryDependencies ++= Seq(
       "com.github.sbt"    % "junit-interface"   % "0.13.3" % Test,

--- a/project/ChangeNotes.scala
+++ b/project/ChangeNotes.scala
@@ -1,6 +1,6 @@
 object ChangeNotes {
   val value =
     """<![CDATA[
-    <p>Support for IntelliJ IDEA 2025.2</p>
+    <p>Support for IntelliJ IDEA 2025.3</p>
   ]]>"""
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.jetbrains.scala" % "sbt-idea-plugin" % "5.0.8")
+addSbtPlugin("org.jetbrains.scala" % "sbt-idea-plugin" % "5.1.0-RC4")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"    % "2.4.6")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,7 +23,7 @@
 
     <change-notes>replaced-by-build</change-notes>
 
-    <idea-version since-build="252" until-build="252.*"/>
+    <idea-version since-build="252" until-build="253.*"/>
 
     <depends>org.intellij.scala</depends>
     <depends>com.intellij.java</depends>

--- a/src/test/scala/org/jetbrains/plugins/scala/libraryLoaders/ScalaSDKLoader.scala
+++ b/src/test/scala/org/jetbrains/plugins/scala/libraryLoaders/ScalaSDKLoader.scala
@@ -5,9 +5,15 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.roots.ui.configuration.libraryEditor.ExistingLibraryEditor
 import com.intellij.openapi.vfs.{JarFileSystem, VirtualFile}
 import com.intellij.testFramework.PsiTestUtil
-import org.jetbrains.plugins.scala.extensions.{inWriteAction, ObjectExt, PathExt}
+import org.jetbrains.plugins.scala.extensions.{ObjectExt, PathExt, inWriteAction}
 import org.jetbrains.plugins.scala.project.external.ScalaSdkUtils
-import org.jetbrains.plugins.scala.project.{template, ModuleExt, ScalaLibraryProperties, ScalaLibraryType}
+import org.jetbrains.plugins.scala.project.{
+  ModuleExt,
+  ReplClasspath,
+  ScalaLibraryProperties,
+  ScalaLibraryType,
+  template
+}
 import org.jetbrains.plugins.scala.{DependencyManager, DependencyManagerBase, ScalaVersion}
 import org.junit.Assert._
 
@@ -131,8 +137,14 @@ case class ScalaSDKLoader(
         .getOrElse(createNewLibrary)
 
     inWriteAction {
-      val version    = Artifact.ScalaCompiler.versionOf(compilerFile)
-      val properties = ScalaLibraryProperties(version, compilerClasspath, Seq.empty, compilerBridge)
+      val version = Artifact.ScalaCompiler.versionOf(compilerFile)
+      val properties = ScalaLibraryProperties(
+        version,
+        compilerClasspath,
+        Seq.empty,
+        compilerBridge,
+        ReplClasspath.fromPaths(compilerClasspath)
+      )
 
       val editor = new ExistingLibraryEditor(library, null)
       editor.setType(ScalaLibraryType())

--- a/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectFunctionsTest.scala
+++ b/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectFunctionsTest.scala
@@ -25,8 +25,8 @@ class TaggedInjectorInjectFunctionsTest extends MacrosTest {
     checkTextHasNoErrors(code)
 
   def testApply(): Unit =
-    assertEquals("def apply(arg: _root_.java.lang.String): Name = ???", method("apply").getText)
+    assertEquals("def apply(arg: _root_.scala.Predef.String): Name = ???", method("apply").getText)
 
   def testFrom(): Unit =
-    assertEquals("def from(arg: _root_.java.lang.String): Name = ???", method("from").getText)
+    assertEquals("def from(arg: _root_.scala.Predef.String): Name = ???", method("from").getText)
 }

--- a/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectTest.scala
+++ b/src/test/scala/pl/iterators/kebs/intellij/synthetic/macros/TaggedInjectorInjectTaggedTypeObjectTest.scala
@@ -24,8 +24,8 @@ class TaggedInjectorInjectTaggedTypeObjectTest extends MacrosTest {
 
   def testNameObject(): Unit =
     assertEquals("""object Name {
-        |  def apply(arg: _root_.java.lang.String): Name = ???
-        |  def from(arg: _root_.java.lang.String): Name = ???
+        |  def apply(arg: _root_.scala.Predef.String): Name = ???
+        |  def from(arg: _root_.scala.Predef.String): Name = ???
         |}""".stripMargin, innerObject("Name").getText)
 
   def testIdObject(): Unit =

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.16"
+ThisBuild / version := "0.0.17"


### PR DESCRIPTION
Changes:
- Upgraded IntelliJ Platform to 2025.3 (build 253.28294.334)
- Bumped JDK to 21 (required by the 2025.3 platform and Scala plugin APIs)
- Updated sbt-idea-plugin for 2025.3 compatibility
- Adjusted test setup to match updated Scala plugin APIs

Plugin works correctly on IntelliJ IDEA 2025.2 and 2025.3